### PR TITLE
Updated Ubuntu to 18.04, using install path for 3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 MAINTAINER Joel B 
 
-RUN apt-repository ppa:wireshark-dev/stable -y; \
-    apt-get -y update; \
-    DEBIAN_FRONTEND=noninteractive apt-get --yes install wireshark wireshark-dev git cmake;
+RUN apt-get -y update && apt-get install -y software-properties-common && rm -rf /var/lib/apt/lists/*;
+
+RUN apt-add-repository -u ppa:wireshark-dev/stable -y; \
+    DEBIAN_FRONTEND=noninteractive apt-get --yes install wireshark wireshark-dev git cmake; \
+    rm -rf /var/lib/apt/lists/*; 
 
 #Plugin instalation
 RUN git clone https://github.com/SecureAuthCorp/SAP-Dissection-plug-in-for-Wireshark/ && \
     cd SAP-Dissection-plug-in-for-Wireshark/ && \
     mkdir build && \
     cd build && \
-    cmake -DCMAKE_INSTALL_LIBDIR=/usr/lib/x86_64-linux-gnu/wireshark/plugins/2.6/epan/ .. && \
+    cmake -DCMAKE_INSTALL_LIBDIR=/usr/lib/x86_64-linux-gnu/wireshark/plugins/3.2/epan/ .. && \
     make && \
     make install clean BATCH=yes
 


### PR DESCRIPTION
- Updated the base image to Ubuntu 18.04
- Using the install path for Wireshark 3.2
- Added a first layer to properly install the ppa

The resulting image should run the latest version of the plugin in Wireshark 3.2. The size is even a little bit better:

```
REPOSITORY                        TAG                      IMAGE ID            CREATED             SIZE
wireshark_sap_plugin              latest                   990bdb3d33b3        12 minutes ago      865MB
joelbelena/wireshark_sap_plugin   latest                   ade56af513cf        14 months ago       923MB
```